### PR TITLE
Fixing style name typo

### DIFF
--- a/Styles_Bookmaker.csv
+++ b/Styles_Bookmaker.csv
@@ -67,7 +67,7 @@ Titlepage Translator Name (tran)
 Endnote Text
 Endnote Text (ntx)
 Footnote Text
-Footnote Text (fm)
+Footnote Text (fn)
 Extract - Verse or Poetry (extv)
 Appendix Head (aph)
 Appendix Text (aptx)


### PR DESCRIPTION
Typo in style name was causing allowed styles to be flagged as "non-Bookmaker styles" in the Bookmaker Check macro. @mattretzer can you please review?